### PR TITLE
Fix for Firefox

### DIFF
--- a/src/responsive-fixed-data-table.js
+++ b/src/responsive-fixed-data-table.js
@@ -35,7 +35,7 @@ var ResponsiveFixedDataTable = React.createClass({
 	},
 
 	componentWillUnmount: function() {
-		window.removeEventListener('resize');
+		window.removeEventListener('resize', this._setDimensionsOnState);
 	},
 
 	_attachResizeEvent: function() {


### PR DESCRIPTION
EventTarget.removeEventListener() takes 2 args in Firefox.
