### PR TITLE
make component isomorphic friendly

### DIFF
--- a/src/responsive-fixed-data-table.js
+++ b/src/responsive-fixed-data-table.js
@@ -27,11 +27,11 @@ var ResponsiveFixedDataTable = React.createClass({
 
 	componentDidMount: function() {
 		this._setDimensionsOnState();
+		this._attachResizeEvent();
 	},
 
 	componentWillMount: function() {
 		this._setDimensionsOnState = debounce(this._setDimensionsOnState, this.props.refreshRate);
-		this._attachResizeEvent();
 	},
 
 	componentWillUnmount: function() {


### PR DESCRIPTION
Moved `this._attachResizeEvent();` to `componentDidMount` so it would be run only in browser as it requires `window` object.
