### PR TITLE
disallow undefined height/width

### DIFF
--- a/src/responsive-fixed-data-table.js
+++ b/src/responsive-fixed-data-table.js
@@ -62,8 +62,8 @@ export default class ResponsiveFixedDataTable extends React.Component {
 			const { offsetWidth, offsetHeight } = findDOMNode(this);
 
 			this.setState({
-				gridWidth: offsetWidth,
-				gridHeight: offsetHeight
+				gridWidth: offsetWidth || 1,
+				gridHeight: offsetHeight || 1
 			});
 		}
 	}

--- a/src/responsive-fixed-data-table.js
+++ b/src/responsive-fixed-data-table.js
@@ -7,6 +7,8 @@ import debounce from 'lodash/debounce';
 import assign from 'lodash/assign';
 import isEqual from 'lodash/isEqual';
 
+const initialPixels = 1;
+
 export default class ResponsiveFixedDataTable extends React.Component {
 	constructor(props, context) {
 		super(props, context);
@@ -23,8 +25,8 @@ export default class ResponsiveFixedDataTable extends React.Component {
 	};
 
 	state = {
-		gridWidth: 1,
-		gridHeight: 1
+		gridWidth: initialPixels,
+		gridHeight: initialPixels
 	};
 
 	shouldComponentUpdate(nextProps, nextState) {
@@ -62,8 +64,8 @@ export default class ResponsiveFixedDataTable extends React.Component {
 			const { offsetWidth, offsetHeight } = findDOMNode(this);
 
 			this.setState({
-				gridWidth: offsetWidth || 1,
-				gridHeight: offsetHeight || 1
+				gridWidth: offsetWidth || initialPixels,
+				gridHeight: offsetHeight || initialPixels
 			});
 		}
 	}


### PR DESCRIPTION
I noticed that if I render the responsive table in a context where `offsetWidth` and `offsetHeight` are undefined (such as in a container with `display: none`, or with the React shallow renderer) I was having issues with the underlying fixed-data-table failing props validation because its width and height properties were undefined. This makes sure that the width and height are never undefined.

I could also see a case for making the fallback 0, but since the default width/height is 1 I though this should work.
